### PR TITLE
plugin/rduck: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # rduck.nvim
-Rubber Duck Neovim Plugin
+**Rubber Ducky Neovim Plugin**
+
+A simple Neovim plugin that displays an ASCII or PNG duck image when prompted with the `:Duck` command and a thought-provoking message.
+
+## Usage
+
+Run `:so` in the `plugin/init.lua` file to set up the autocommand.
+
+Run `:Duck` to call the function which displays the Rubber Duck ASCII art and message.

--- a/lua/rduck/init.lua
+++ b/lua/rduck/init.lua
@@ -1,0 +1,54 @@
+local M = {}
+
+M.show_duck = function()
+  local duck_art = [[
+                                  ██████████
+                              ████          ████
+                            ██                  ██
+                          ██            ████      ██  ████
+                        ██            ██    ██    ░░██░░░░██
+                        ██          ██    ██  ██  ░░░░░░░░██
+                        ██          ██        ██  ░░░░░░░░██
+                        ██            ██    ██      ░░░░██
+                        ██              ████        ████
+                        ██                        ██
+                          ██                      ██
+    ██                    ██                    ██
+  ██  ██                    ██                  ██
+  ██    ██                    ██                  ██
+  ██      ██████                ██                  ██
+██              ████████████████                      ██
+██              ░░░░░░░░░░░░░░░░                      ░░██
+██                                                        ██
+██                                                        ██
+██                                                        ██
+██                                                        ██
+  ██        ████████████                  ██              ██
+  ██            █░░░                       ██             ██
+    ██          ██████████                ██            ██
+    ██            █░░░                  ██              ██
+      ██            ██████        ██████              ██
+        ██                ████████                  ██
+          ████                                  ████░░
+              ████                        ██████
+                  ████████████████████████
+  ]]
+  vim.api.nvim_out_write(duck_art .. "\n")
+end
+
+M.show_message = function()
+    local messages = {
+        "Am I repeating any code?",
+        "Take a break, you deserve it!",
+        "Did you check for edge cases?",
+        "Could this be simplified?",
+        "Is the function name clear enough?",
+        "Are the variable names meaningful?",
+        "Have you considered testing this?"
+    }
+
+    local message = messages[math.random(#messages)]
+    vim.api.nvim_out_write(message .. "\n")
+end
+
+return M

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -1,0 +1,5 @@
+vim.api.nvim_create_user_command("Duck", function ()
+    package.loaded.rduck = nil
+    require('rduck').show_duck()
+    require('rduck').show_message()
+end, {})


### PR DESCRIPTION
# Description
Add Initial implementation of the rduck.nvim plugin. This is a simple plugin which can help developers follow the rubber-duck debugging process by displaying a duck ASCII art which engulfs the entire NeoVim pane.

# Usage
`:so` plugin/init.lua to set up ":Duck"
`:Duck` Call the function which displays the Rubber Duck ASCII art.

